### PR TITLE
Fixed failing tests issues with default grade config by upgrading to

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'appengine'
 
 buildscript {
     ext {
-        gaeVersion = '1.9.24'
+        gaeVersion = '1.9.26'
     }
     repositories {
         mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip


### PR DESCRIPTION
Gradle 2.7, GAE 1.9.26.
